### PR TITLE
Fixing defintions of q'/r' in one-step

### DIFF
--- a/R/estim_onestep.R
+++ b/R/estim_onestep.R
@@ -243,9 +243,7 @@ cv_eif <- function(fold,
   # NOTE: we only do this for observations in the validation set
   m_prime <- m_out$m_est_valid$m_pred_A_prime
   q_prime <- q_out$moc_est_valid$moc_pred_A_prime
-    #* valid_data$Z + (1 - q_out$moc_est_valid$moc_pred_A_prime) * (1 - valid_data$Z)
   r_prime <- r_out$moc_est_valid$moc_pred_A_prime
-    #* valid_data$Z + (1 - r_out$moc_est_valid$moc_pred_A_prime) * (1 - valid_data$Z)
   e_prime <- e_out$treat_est_valid$treat_pred_A_prime
   e_star <- e_out$treat_est_valid$treat_pred_A_star
   g_star <- g_out$treat_est_valid$treat_pred_A_star
@@ -314,6 +312,12 @@ cv_eif <- function(fold,
   # create inverse probability weights
   ipw_a_prime <- as.numeric(valid_data$A == contrast[1]) / g_star
   ipw_a_star <- as.numeric(valid_data$A == contrast[2]) / g_star
+
+  # use natural definitions of q' and r' for efficient influence function
+  q_prime <- q_out$moc_est_valid$moc_pred_A_prime * valid_data$Z +
+    (1 - q_out$moc_est_valid$moc_pred_A_prime) * (1 - valid_data$Z)
+  r_prime <- r_out$moc_est_valid$moc_pred_A_prime * valid_data$Z +
+    (1 - r_out$moc_est_valid$moc_pred_A_prime) * (1 - valid_data$Z)
 
   # compute efficient influence function
   eif_resid_y <- (q_prime / r_prime) * (e_star / e_prime) *


### PR DESCRIPTION
The one-step estimator requires re-defining the nuisance parameters q' and r' in definition of the efficient influence function. This PR moves re-defining those quantities (based on the observed value of the mediator-outcome confounder Z) to right before the EIF, as re-defining prior causes problems in computing certain integrals needed in the EIF.